### PR TITLE
tryton : add Coog version and Copyright in Help Menu (About...)

### DIFF
--- a/tryton/__init__.py
+++ b/tryton/__init__.py
@@ -1,3 +1,4 @@
 # This file is part of Tryton.  The COPYRIGHT file at the top level of
 # this repository contains the full copyright notices and license terms.
 __version__ = "4.0.6"
+__version_coog__ = "1.10"

--- a/tryton/gui/window/about.py
+++ b/tryton/gui/window/about.py
@@ -6,9 +6,10 @@ import gettext
 import webbrowser
 from tryton.config import TRYTON_ICON
 from tryton.common import get_toplevel_window
-from tryton import __version__
+from tryton import __version_coog__
 
 COPYRIGHT = '''\
+Copyright (C) 2012-2016 Coopengo
 Copyright (C) 2010-2011 Nicolas Évrard.
 Copyright (C) 2007-2011 Cédric Krier.
 Copyright (C) 2007-2011 Bertrand Chenal.
@@ -18,6 +19,10 @@ Copyright (C) 2008-2011 virtual things - Preisler & Spallek GbR.
 Copyright (C) 2007-2009 Lorenzo Gil Sanchez.
 Copyright (C) 2004-2008 Tiny SPRL.
 '''
+
+"""
+#5107 : qui ajouter dans la partie 'AUTHORS' pour Coog ?
+"""
 AUTHORS = [
         'Bertrand Chenal <bertrand.chenal@b2ck.com>',
         'Cédric Krier <cedric.krier@b2ck.com>',
@@ -718,11 +723,14 @@ class About(object):
         parent = get_toplevel_window()
         self.win = gtk.AboutDialog()
         self.win.set_transient_for(parent)
-        self.win.set_name('Tryton')
-        self.win.set_version(__version__)
+        # replace self.win.set_name('Tryton')
+        self.win.set_name('Coog')
+        # replace self.win.set_version('__version__')
+        self.win.set_version(__version_coog__)
         self.win.set_copyright(COPYRIGHT)
         self.win.set_license(LICENSE)
-        self.win.set_website('http://www.tryton.org/')
+        # replace self.win.set_website('http://tryton.org/')
+        self.win.set_website('http://coopengo.com/')
         self.win.set_authors(AUTHORS)
         self.win.set_logo(TRYTON_ICON)
 

--- a/tryton/gui/window/about.py
+++ b/tryton/gui/window/about.py
@@ -9,7 +9,7 @@ from tryton.common import get_toplevel_window
 from tryton import __version_coog__
 
 COPYRIGHT = '''\
-Copyright (C) 2012-2016 Coopengo
+Copyright (C) 2012-2016 Coopengo.
 Copyright (C) 2010-2011 Nicolas Évrard.
 Copyright (C) 2007-2011 Cédric Krier.
 Copyright (C) 2007-2011 Bertrand Chenal.

--- a/tryton/gui/window/about.py
+++ b/tryton/gui/window/about.py
@@ -19,10 +19,6 @@ Copyright (C) 2008-2011 virtual things - Preisler & Spallek GbR.
 Copyright (C) 2007-2009 Lorenzo Gil Sanchez.
 Copyright (C) 2004-2008 Tiny SPRL.
 '''
-
-"""
-#5107 : qui ajouter dans la partie 'AUTHORS' pour Coog ?
-"""
 AUTHORS = [
         'Bertrand Chenal <bertrand.chenal@b2ck.com>',
         'Cédric Krier <cedric.krier@b2ck.com>',
@@ -33,6 +29,7 @@ AUTHORS = [
         'Nicolas Évrard <nicolas.evrard@b2ck.com>',
         'Sednacom <contact@sednacom.fr>',
         'Udo Spallek <info@virtual-things.biz>',
+        'Coopengo <support@coopengo.com>',
         ]
 LICENSE = '''                    GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
@@ -723,13 +720,11 @@ class About(object):
         parent = get_toplevel_window()
         self.win = gtk.AboutDialog()
         self.win.set_transient_for(parent)
-        # replace self.win.set_name('Tryton')
+        # MAR : Fix #5107 : Replace tryton references with Coog
         self.win.set_name('Coog')
-        # replace self.win.set_version('__version__')
         self.win.set_version(__version_coog__)
         self.win.set_copyright(COPYRIGHT)
         self.win.set_license(LICENSE)
-        # replace self.win.set_website('http://tryton.org/')
         self.win.set_website('http://coopengo.com/')
         self.win.set_authors(AUTHORS)
         self.win.set_logo(TRYTON_ICON)


### PR DESCRIPTION
This include the current version of Coog (1.10), the website link and the copyright for Coopengo. 

Feature #5107 