### PR TITLE
tryton: add support for toggling view

### DIFF
--- a/tryton/gui/window/view_form/model/record.py
+++ b/tryton/gui/window/view_form/model/record.py
@@ -69,6 +69,7 @@ class Record(SignalEvent):
             else:
                 fnames = self.group.fields.keys()
 
+            # PJA: load fields that are required
             if self.fields_to_load:
                 fnames = [fname for fname in fnames
                     if fname in self.fields_to_load]

--- a/tryton/gui/window/view_form/model/record.py
+++ b/tryton/gui/window/view_form/model/record.py
@@ -41,6 +41,7 @@ class Record(SignalEvent):
         self.autocompletion = {}
         self.exception = False
         self.destroyed = False
+        self.fields_to_load = []
 
     def __getitem__(self, name):
         if name not in self._loaded and self.id >= 0:
@@ -67,6 +68,12 @@ class Record(SignalEvent):
                     if field.attrs.get('loading', 'eager') == 'eager']
             else:
                 fnames = self.group.fields.keys()
+
+            if self.fields_to_load:
+                fnames = [fname for fname in fnames
+                    if fname in self.fields_to_load]
+                self.fields_to_load = []
+
             fnames = [fname for fname in fnames if fname not in self._loaded]
             fnames.extend(('%s.rec_name' % fname for fname in fnames[:]
                     if self.group.fields[fname].attrs['type']

--- a/tryton/gui/window/view_form/model/record.py
+++ b/tryton/gui/window/view_form/model/record.py
@@ -72,8 +72,6 @@ class Record(SignalEvent):
             if self.fields_to_load:
                 fnames = [fname for fname in fnames
                     if fname in self.fields_to_load]
-                self.fields_to_load = []
-
             fnames = [fname for fname in fnames if fname not in self._loaded]
             fnames.extend(('%s.rec_name' % fname for fname in fnames[:]
                     if self.group.fields[fname].attrs['type']

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -1167,7 +1167,6 @@ class Screen(SignalEvent):
         elif action.startswith('toggle'):
             # PJA: handle a custom action to toggle views
             _, view_id = action.split(':')
-            self.current_view._single_view = False
             self.switch_view(view_id=int(view_id))
         elif action == 'reload':
             if (self.current_view.view_type in ['tree', 'graph', 'calendar']

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -1114,8 +1114,9 @@ class Screen(SignalEvent):
                 ids, context=context)
         except RPCException:
             action = None
-        if (action and isinstance(action, int) or
-                not action.startswith('toggle')):
+        if action and action.startswith('toggle'):
+            pass
+        else:
             self.reload(ids, written=True)
         if isinstance(action, basestring):
             self.client_action(action)

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -489,7 +489,7 @@ class Screen(SignalEvent):
                     self.__current_view = ((self.__current_view + 1)
                             % len(self.views))
                 if view_id:
-                    if self.current_view.view_id == int(view_id):
+                    if self.current_view.view_id == view_id:
                         break
                 elif not view_type:
                     break
@@ -534,6 +534,8 @@ class Screen(SignalEvent):
 
         # Ensure that loading is always lazy for fields on form view
         # and always eager for fields on tree or graph view
+
+        # PJA: backup && clear the fields so not all fields are loaded
         old_group = self.group.fields
         self.group.fields = {}
         for field in fields:
@@ -545,6 +547,7 @@ class Screen(SignalEvent):
         view = View.parse(self, xml_dom, view.get('field_childs'),
             view.get('children_definitions'))
         view.view_id = view_id
+        # PJA: set only the fields that need to be loaded
         view._fields = self.group.fields
         view._field_keys = view._fields.keys()
         self.group.fields = old_group
@@ -868,6 +871,7 @@ class Screen(SignalEvent):
             self.search_active(self.current_view.view_type
                 in ('tree', 'graph', 'calendar'))
             self.current_view.display()
+            # PJA: there is no reason to loop over each view and display
             #  for view in self.views:
             #      view.display()
             self.current_view.widget.set_sensitive(
@@ -1155,9 +1159,9 @@ class Screen(SignalEvent):
             _, view_type = action.split(None, 1)
             self.switch_view(view_type=view_type)
         elif action.startswith('toggle'):
-            #  import rpdb; rpdb.set_trace()
+            # PJA: handle a custom action to toggle views
             _, view_id = action.split(':')
-            self.switch_view(None, view_id)
+            self.switch_view(view_id=int(view_id))
         elif action == 'reload':
             if (self.current_view.view_type in ['tree', 'graph', 'calendar']
                     and not self.parent):

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -1114,7 +1114,8 @@ class Screen(SignalEvent):
                 ids, context=context)
         except RPCException:
             action = None
-        if action and action.startswith('toggle'):
+        if (action and isinstance(action, basestring)
+                and action.startswith('toggle')):
             pass
         else:
             self.reload(ids, written=True)

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -870,11 +870,9 @@ class Screen(SignalEvent):
         if self.views:
             self.search_active(self.current_view.view_type
                 in ('tree', 'graph', 'calendar'))
-
-            # if getattr(self, '__single_view', False) is True
+            
             self.current_view.display()
-            #  for view in self.views:
-            #      view.display()
+
             self.current_view.widget.set_sensitive(
                 bool(self.group
                     or (self.current_view.view_type != 'form')
@@ -1122,12 +1120,10 @@ class Screen(SignalEvent):
         else:
             action_id, action = None, action
 
-        # TODO
-        if (action and isinstance(action, basestring)
-                and action.startswith('toggle')):
-            pass
-        else:
+        if (not action or not isinstance(action, basestring) or
+                not action.startswith('toggle')):
             self.reload(ids, written=True)
+
         if isinstance(action, basestring):
             self.client_action(action)
             if action.startswith('toggle'):

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -1110,7 +1110,8 @@ class Screen(SignalEvent):
                 ids, context=context)
         except RPCException:
             action = None
-        if action and not action.startswith('toggle'):
+        if (action and isinstance(action, int) or
+                not action.startswith('toggle')):
             self.reload(ids, written=True)
         if isinstance(action, basestring):
             self.client_action(action)

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -870,10 +870,8 @@ class Screen(SignalEvent):
         if self.views:
             self.search_active(self.current_view.view_type
                 in ('tree', 'graph', 'calendar'))
-            self.current_view.display()
-            # PJA: there is no reason to loop over each view and display
-            #  for view in self.views:
-            #      view.display()
+            for view in self.views:
+                view.display()
             self.current_view.widget.set_sensitive(
                 bool(self.group
                     or (self.current_view.view_type != 'form')
@@ -1162,6 +1160,7 @@ class Screen(SignalEvent):
             self.switch_view(view_type=view_type)
         elif action.startswith('toggle'):
             # PJA: handle a custom action to toggle views
+            #  import rpdb; rpdb.set_trace()
             _, view_id = action.split(':')
             self.switch_view(view_id=int(view_id))
         elif action == 'reload':

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -549,6 +549,7 @@ class Screen(SignalEvent):
             view.get('children_definitions'))
         view.view_id = view_id
         self.views.append(view)
+        # PJA: set list of fields to use on the view
         view._field_keys = fields.keys()
 
         return view
@@ -1113,6 +1114,8 @@ class Screen(SignalEvent):
                 ids, context=context)
         except RPCException:
             action = None
+
+        # PJA: handle different returns values from button
         if isinstance(action, list):
             action_id, action = action
         elif isinstance(action, int):

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -538,14 +538,12 @@ class Screen(SignalEvent):
             loading = 'lazy'
         else:
             loading = 'eager'
-
         for field in fields:
             if field not in self.group.fields or loading == 'eager':
                 fields[field]['loading'] = loading
             else:
                 fields[field]['loading'] = \
                     self.group.fields[field].attrs['loading']
-
         self.group.add_fields(fields)
         view = View.parse(self, xml_dom, view.get('field_childs'),
             view.get('children_definitions'))
@@ -870,6 +868,9 @@ class Screen(SignalEvent):
             self.search_active(self.current_view.view_type
                 in ('tree', 'graph', 'calendar'))
 
+            # PJA: we are greedy people
+            #  for view in self.views:
+            #      view.display()
             self.current_view.display()
 
             self.current_view.widget.set_sensitive(
@@ -1122,7 +1123,6 @@ class Screen(SignalEvent):
         if (not action or not isinstance(action, basestring) or
                 not action.startswith('toggle')):
             self.reload(ids, written=True)
-
         if isinstance(action, basestring):
             self.client_action(action)
             if action.startswith('toggle'):

--- a/tryton/gui/window/view_form/view/__init__.py
+++ b/tryton/gui/window/view_form/view/__init__.py
@@ -11,6 +11,7 @@ class View(object):
     editable = None
     children_field = None
     children_definitions = None
+    _single_view = True
 
     def __init__(self, screen, xml):
         self.screen = screen

--- a/tryton/gui/window/view_form/view/__init__.py
+++ b/tryton/gui/window/view_form/view/__init__.py
@@ -11,7 +11,6 @@ class View(object):
     editable = None
     children_field = None
     children_definitions = None
-    _single_view = True
 
     def __init__(self, screen, xml):
         self.screen = screen

--- a/tryton/gui/window/view_form/view/form.py
+++ b/tryton/gui/window/view_form/view/form.py
@@ -460,8 +460,9 @@ class ViewForm(View):
             # Force to set fields in record
             # Get first the lazy one to reduce number of requests
             fields = [(name, field.attrs.get('loading', 'eager'))
-                    for name, field in record.group.fields.iteritems()]
+                    for name, field in self._fields.iteritems()]
             fields.sort(key=operator.itemgetter(1), reverse=True)
+            record.fields_to_load = self._field_keys
             for field, _ in fields:
                 record[field].get(record)
         focused_widget = find_focused_child(self.widget)

--- a/tryton/gui/window/view_form/view/form.py
+++ b/tryton/gui/window/view_form/view/form.py
@@ -460,13 +460,9 @@ class ViewForm(View):
             # Force to set fields in record
             # Get first the lazy one to reduce number of requests
             # PJA: iter only over the fields that need to be loaded
-            if self._single_view is True:
-                fields = [(name, field.attrs.get('loading', 'eager'))
-                    for name, field in record.group.fields.iteritems()]
-            else:
-                fields = [(name, record.group.fields.get(name).attrs.get(
-                            'loading', 'eager'))
-                    for name in self._field_keys]
+            fields = [(name, record.group.fields.get(name).attrs.get(
+                        'loading', 'eager'))
+                for name in self._field_keys]
             fields.sort(key=operator.itemgetter(1), reverse=True)
             record.fields_to_load = self._field_keys
             for field, _ in fields:

--- a/tryton/gui/window/view_form/view/form.py
+++ b/tryton/gui/window/view_form/view/form.py
@@ -460,8 +460,13 @@ class ViewForm(View):
             # Force to set fields in record
             # Get first the lazy one to reduce number of requests
             # PJA: iter only over the fields that need to be loaded
-            fields = [(name, field.attrs.get('loading', 'eager'))
-                    for name, field in self._fields.iteritems()]
+            if self._single_view is True:
+                fields = [(name, field.attrs.get('loading', 'eager'))
+                    for name, field in record.group.fields.iteritems()]
+            else:
+                fields = [(name, record.group.fields.get(name).attrs.get(
+                            'loading', 'eager'))
+                    for name in self._field_keys]
             fields.sort(key=operator.itemgetter(1), reverse=True)
             record.fields_to_load = self._field_keys
             for field, _ in fields:

--- a/tryton/gui/window/view_form/view/form.py
+++ b/tryton/gui/window/view_form/view/form.py
@@ -459,6 +459,7 @@ class ViewForm(View):
         if record:
             # Force to set fields in record
             # Get first the lazy one to reduce number of requests
+            # PJA: iter only over the fields that need to be loaded
             fields = [(name, field.attrs.get('loading', 'eager'))
                     for name, field in self._fields.iteritems()]
             fields.sort(key=operator.itemgetter(1), reverse=True)

--- a/tryton/gui/window/view_form/view/form.py
+++ b/tryton/gui/window/view_form/view/form.py
@@ -467,6 +467,7 @@ class ViewForm(View):
             record.fields_to_load = self._field_keys
             for field, _ in fields:
                 record[field].get(record)
+            record.fields_to_load = []
         focused_widget = find_focused_child(self.widget)
         for name, widgets in self.widgets.iteritems():
             field = None


### PR DESCRIPTION
Allows toggling views. Specifically for processes in order to split the process view into multiple views

Ref #6394