### PR TITLE
tryton : Pyson context has priority over existing context

### DIFF
--- a/tryton/action/main.py
+++ b/tryton/action/main.py
@@ -126,8 +126,9 @@ class Action(object):
             ctx['_user'] = rpc._USER
             decoder = PYSONDecoder(ctx)
             # TODO: comment changes
-            action_ctx = decoder.decode(action.get('pyson_context') or '{}')
-            action_ctx.update(context)
+            action_ctx = context.copy()
+            action_ctx.update(decoder.decode(
+                    action.get('pyson_context') or '{}'))
             action_ctx.update(ctx)
             action_ctx.update(data.get('extra_context', {}))
             action_ctx['context'] = ctx


### PR DESCRIPTION
When handling new actions, the client should consider the pyson_context with
a higher priority than the existing tab context in order to allow overwriting
if necessary

Fix #6533