### PR TITLE
tryton : Set icon factory size to 100

### DIFF
--- a/tryton/common/common.py
+++ b/tryton/common/common.py
@@ -1436,6 +1436,7 @@ def resize_pixbuf(pixbuf, width, height):
 
 def _data2pixbuf(data):
     loader = gtk.gdk.PixbufLoader()
+    loader.set_size(100, 100)
     loader.write(bytes(data))
     loader.close()
     return loader.get_pixbuf()


### PR DESCRIPTION
This forces the scaling of svg files to 100, so that icons /
images displays are down-scaling rather than up-scaling