### PR TITLE
Load autocomplete only on display of Char widget

### DIFF
--- a/tryton/gui/window/view_form/model/record.py
+++ b/tryton/gui/window/view_form/model/record.py
@@ -394,10 +394,6 @@ class Record(SignalEvent):
                         == self.group.parent.model_name):
                     vals[self.parent_name] = self.parent.id
             self.set_default(vals)
-        for fieldname, fieldinfo in self.group.fields.iteritems():
-            if not fieldinfo.attrs.get('autocomplete'):
-                continue
-            self.do_autocomplete(fieldname)
         return vals
 
     def rec_name(self):
@@ -490,9 +486,6 @@ class Record(SignalEvent):
         for fieldname, value in later.iteritems():
             self.group.fields[fieldname].set(self, value)
             self._loaded.add(fieldname)
-        for fieldname, fieldinfo in self.group.fields.iteritems():
-            if fieldinfo.attrs.get('autocomplete'):
-                self.do_autocomplete(fieldname)
         if validate:
             self.validate(fieldnames, softvalidation=True)
         if signal:

--- a/tryton/gui/window/view_form/view/form_gtk/char.py
+++ b/tryton/gui/window/view_form/view/form_gtk/char.py
@@ -111,6 +111,8 @@ class Char(Widget, TranslateMixin, PopdownMixin):
         super(Char, self).display(record, field)
         if self.autocomplete:
             if record:
+                if self.field_name not in record.autocompletion:
+                    record.do_autocomplete(self.field_name)
                 selection = record.autocompletion.get(self.field_name, [])
             else:
                 selection = []


### PR DESCRIPTION
Keeping the autocomplete always up to date is very expensive especially
for large list because the method is called once per field for each
record. Indeed autocomplete is only needed when the Char widget is
displayed. So we could just load it at display and keep it up to date
when fields are changed.