### PR TITLE
Set to eager every field of the multi-model treeview children definitions

### DIFF
--- a/tryton/gui/window/view_form/model/record.py
+++ b/tryton/gui/window/view_form/model/record.py
@@ -196,6 +196,9 @@ class Record(SignalEvent):
             group._context.update(self.group._context)
         else:
             fields = children_definitions[group.model_name].copy()
+            # Force every field of the multi-model to be eager-loaded
+            for field_def in fields.values():
+                field_def['loading'] = 'eager'
             group.load_fields(fields)
         return group
 


### PR DESCRIPTION
That way the loading of them should be grouped.