### PR TITLE
Connect dict widgets to the right activate callback

### DIFF
--- a/tryton/gui/window/view_form/view/form_gtk/checkbox.py
+++ b/tryton/gui/window/view_form/view/form_gtk/checkbox.py
@@ -28,4 +28,8 @@ class CheckBox(Widget):
         if not field:
             self.widget.set_active(False)
             return False
-        self.widget.set_active(bool(field.get(record)))
+        self.widget.handler_block_by_func(self.sig_activate)
+        try:
+            self.widget.set_active(bool(field.get(record)))
+        finally:
+            self.widget.handler_unblock_by_func(self.sig_activate)


### PR DESCRIPTION
On activate of Entry and on toggle CheckButton, the parent must be activate.
The toggled handler must also be blocked when activate the CheckButton
by code to avoid unnecessary callbacks.

https://support.coopengo.com/issues/10689