### PR TITLE
Catch ProtocolError on second EPIPE call in jsonrpc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* BUG#10995: Catch error in case of timeout
+
 Version 4.6.5 - 2018-04-03
 * Bug fixes (see mercurial logs for details)
 

--- a/tryton/jsonrpc.py
+++ b/tryton/jsonrpc.py
@@ -325,24 +325,25 @@ class ServerProxy(xmlrpclib.ServerProxy):
                 }, cls=JSONEncoder, separators=(',', ':'))
 
         try:
-            response = self.__transport.request(
-                self.__host,
-                self.__handler,
-                request,
-                verbose=self.__verbose
-                )
-        except (socket.error, httplib.HTTPException), v:
-            if (isinstance(v, socket.error)
-                    and v.args[0] == errno.EPIPE):
-                raise
-            # try one more time
-            self.__transport.close()
-            response = self.__transport.request(
-                self.__host,
-                self.__handler,
-                request,
-                verbose=self.__verbose
-                )
+            try:
+                response = self.__transport.request(
+                    self.__host,
+                    self.__handler,
+                    request,
+                    verbose=self.__verbose
+                    )
+            except (socket.error, httplib.HTTPException), v:
+                if (isinstance(v, socket.error)
+                        and v.args[0] == errno.EPIPE):
+                    raise
+                # try one more time
+                self.__transport.close()
+                response = self.__transport.request(
+                    self.__host,
+                    self.__handler,
+                    request,
+                    verbose=self.__verbose
+                    )
         except xmlrpclib.ProtocolError, e:
             raise Fault(str(e.errcode), e.errmsg)
         except:

--- a/tryton/jsonrpc.py
+++ b/tryton/jsonrpc.py
@@ -337,12 +337,15 @@ class ServerProxy(xmlrpclib.ServerProxy):
                 raise
             # try one more time
             self.__transport.close()
-            response = self.__transport.request(
-                self.__host,
-                self.__handler,
-                request,
-                verbose=self.__verbose
-                )
+            try:
+                response = self.__transport.request(
+                    self.__host,
+                    self.__handler,
+                    request,
+                    verbose=self.__verbose
+                    )
+            except xmlrpclib.ProtocolError, e:
+                raise Fault(str(e.errcode), e.errmsg)
         except xmlrpclib.ProtocolError, e:
             raise Fault(str(e.errcode), e.errmsg)
         except:

--- a/tryton/jsonrpc.py
+++ b/tryton/jsonrpc.py
@@ -337,15 +337,12 @@ class ServerProxy(xmlrpclib.ServerProxy):
                 raise
             # try one more time
             self.__transport.close()
-            try:
-                response = self.__transport.request(
-                    self.__host,
-                    self.__handler,
-                    request,
-                    verbose=self.__verbose
-                    )
-            except xmlrpclib.ProtocolError, e:
-                raise Fault(str(e.errcode), e.errmsg)
+            response = self.__transport.request(
+                self.__host,
+                self.__handler,
+                request,
+                verbose=self.__verbose
+                )
         except xmlrpclib.ProtocolError, e:
             raise Fault(str(e.errcode), e.errmsg)
         except:


### PR DESCRIPTION
cherry-pick from : https://hg.tryton.org/tryton/rev/b7aed1acb605

Fix #10995