### PR TITLE
Add never_modified flag to fields

### DIFF
--- a/tryton/gui/window/view_form/model/record.py
+++ b/tryton/gui/window/view_form/model/record.py
@@ -146,8 +146,19 @@ class Record(SignalEvent):
         result = bool(self.modified_fields)
         if not result:
             return result
-        logging.getLogger('root').debug('%s : modfied fields : %s' % (self,
-                self.modified_fields))
+        # JCA: Add a way to make sure some fields are always ignored when
+        # detecting whether the record needs saving
+        for field in self.modified_fields:
+            if field not in self.group.fields:
+                break
+            if not self.group.fields[field].attrs.get(
+                    'never_modified', False):
+                break
+        else:
+            return False
+        logging.getLogger('root').critical(
+            '%s : modified fields : %s' % (
+                self, list(self.modified_fields.keys())))
         return result
 
     @property

--- a/tryton/gui/window/view_form/model/record.py
+++ b/tryton/gui/window/view_form/model/record.py
@@ -146,7 +146,7 @@ class Record(SignalEvent):
         result = bool(self.modified_fields)
         if not result:
             return result
-        # JCA: Add a way to make sure some fields are always ignored when
+        # JCA #15014 Add a way to make sure some fields are always ignored when
         # detecting whether the record needs saving
         for field in self.modified_fields:
             if field not in self.group.fields:


### PR DESCRIPTION
 This can be used server side by adding a field
 to the '_never_modified_field' set in the setup
 of the model.

 The client will then never consider this field
 as modified when checking if the save button is
 available