### PR TITLE
theme: Do not "readonly" editable comboboxes in tree views

### DIFF
--- a/share/themes/Coog/gtk-3.20/gtk-widgets-borders.css
+++ b/share/themes/Coog/gtk-3.20/gtk-widgets-borders.css
@@ -189,6 +189,36 @@ combobox button:backdrop {
     margin:2px 2px 2px 0;
 }
 
+frame.readonly combobox entry:first-child:focus,
+frame.readonly combobox entry:last-child:focus ~ button:first-child {
+    border-radius: 5px 0 0 5px;
+    border-width: 2px 0 2px 2px;
+    margin: 0;
+    border-style: solid;
+    border-color: @shape_color;
+    border-image:none;
+}
+
+frame.readonly combobox entry:first-child:last-child:focus,
+frame.readonly combobox button:first-child:last-child:focus {
+    border-radius: 5px;
+    border-width: 2px;
+    margin:0;
+    border-style: solid;
+    border-color: @shape_color;
+    border-image:none;
+}
+
+frame.readonly combobox entry:last-child:focus,
+frame.readonly combobox entry:first-child:focus + button:last-child {
+    border-radius: 0 5px 5px 0;
+    border-width: 2px 2px 2px 0;
+    margin:0;
+    border-style: solid;
+    border-color: @shape_color;
+    border-image:none;
+}
+
 .primary-toolbar combobox entry button,
 .primary-toolbar combobox entry button:focus:disabled,
 menubar toolbar combobox entry button,

--- a/share/themes/Coog/gtk-3.20/gtk-widgets.css
+++ b/share/themes/Coog/gtk-3.20/gtk-widgets.css
@@ -261,6 +261,7 @@ combobox {
 	text-shadow: 0 1px @button_text_shadow;
 }
 
+combobox:readonly,
 combobox:disabled {
 	text-shadow: none;
 	color: @insensitive_fg_color;
@@ -277,8 +278,8 @@ combobox arrow {
 }
 
 combobox arrow:disabled,
-combobox arrow:backdrop,
-*.readonly combobox arrow {
+combobox.readonly arrow:backdrop,
+combobox.readonly arrow {
     color: transparent;
 }
 
@@ -496,27 +497,41 @@ entry:selected:backdrop {
     background-image:none;
 }
 
-*.readonly spinbutton,
-*.readonly entry,
-*.readonly spinbutton:focus,
-*.readonly entry:focus,
 *.readonly combobox button,
-*.readonly combobox entry,
-*.readonly combobox entry:first-child:focus + button:last-child,
-*.readonly combobox entry:last-child:focus ~ button:first-child,
-*.readonly entry:focus,
-*.readonly spinbutton:backdrop,
-*.readonly entry:backdrop,
-*.readonly spinbutton:focus:backdrop,
-*.readonly entry:focus:backdrop,
 *.readonly combobox button:backdrop,
+*.readonly combobox entry,
 *.readonly combobox entry:backdrop,
+*.readonly combobox entry:first-child:focus + button:last-child,
 *.readonly combobox entry:first-child:focus + button:last-child:backdrop,
+*.readonly combobox entry:last-child:focus ~ button:first-child,
 *.readonly combobox entry:last-child:focus ~ button:first-child:backdrop,
-*.readonly entry:focus:backdrop{
+*.readonly entry,
+*.readonly entry:backdrop,
+*.readonly entry:focus,
+*.readonly entry:focus:backdrop,
+*.readonly spinbutton,
+*.readonly spinbutton:backdrop,
+*.readonly spinbutton:focus,
+*.readonly spinbutton:focus:backdrop
+{
     background-image: -gtk-gradient (linear, left top, left bottom,
                                      from (shade (@readonly_bg_color, 0.98)),
                                      to (shade (@readonly_bg_color, 1)));
+    color:@text_color;
+}
+
+frame.readonly combobox button,
+frame.readonly combobox button:backdrop,
+frame.readonly combobox entry,
+frame.readonly combobox entry:focus,
+frame.readonly combobox entry:focus:backdrop,
+frame.readonly combobox entry:first-child:focus + button:last-child,
+frame.readonly combobox entry:first-child:focus + button:last-child:backdrop,
+frame.readonly combobox entry:last-child:focus ~ button:first-child,
+frame.readonly combobox entry:last-child:focus ~ button:first-child:backdrop
+{
+    background-color: @bg_color;
+    background-image:none;
     color:@text_color;
 }
 


### PR DESCRIPTION
We are using very "wide" flags for readonly (*.readonly),
so for a combobox that is inside an editable tree of a
readonly O2M field, the applied css is that of a readonly
combobox, even though it itself is not readonly.

So in this particular case, we restore the non-readonly
behaviour as much as possible.

Ideally we should make sure the "*.readonly" is properly
limited, but we rely on it being broad for a lot of cases
so...

Fix #16422