### PR TITLE
PYSON's DateTime defaults to the current time in UTC

### DIFF
--- a/tryton/pyson.py
+++ b/tryton/pyson.py
@@ -630,7 +630,7 @@ class DateTime(Date):
                 and not isinstance(now, datetime.datetime)):
             now = datetime.datetime.combine(now, datetime.time())
         if not isinstance(now, datetime.datetime):
-            now = datetime.datetime.now()
+            now = datetime.datetime.utcnow()
         return now + relativedelta(
             year=dct['y'],
             month=dct['M'],


### PR DESCRIPTION
Fix #17400