### PR TITLE
Fix wrong translation msgids

### DIFF
--- a/tryton/data/locale/fr/LC_MESSAGES/tryton.po
+++ b/tryton/data/locale/fr/LC_MESSAGES/tryton.po
@@ -119,8 +119,8 @@ msgstr "Rapporter un bogue"
 msgid "Check URL: %s"
 msgstr "Vérification de l'URL: %s"
 
-msgid "Unable to check for new version"
-msgstr "Impossible de vérifier les nouvelles versions"
+msgid "Unable to check for new version."
+msgstr "Impossible de vérifier les nouvelles versions."
 
 msgid "A new version is available!"
 msgstr "Un nouvelle version est disponible !"
@@ -481,11 +481,11 @@ msgstr "Récupération de la liste des bases de données"
 msgid "Username:"
 msgstr "Nom d'utilisateur :"
 
-msgid "Incompatible version of the server"
-msgstr "Version du serveur incompatible"
+msgid "Incompatible version of the server."
+msgstr "Version du serveur incompatible."
 
-msgid "Could not connect to the server"
-msgstr "Impossible de se connecter au serveur"
+msgid "Could not connect to the server."
+msgstr "Impossible de se connecter au serveur."
 
 msgid "Login"
 msgstr "Connexion"
@@ -957,16 +957,16 @@ msgid "Unable to set view tree state"
 msgstr "Impossible de définir l'état de la vue arbre"
 
 #, python-format
-msgid "\"%s\" is not valid according to its domain"
-msgstr "« %s » n'est pas valide selon son domaine"
+msgid "\"%s\" is not valid according to its domain."
+msgstr "« %s » n'est pas valide selon son domaine."
 
 #, python-format
-msgid "\"%s\" is required"
-msgstr "« %s » est requis"
+msgid "\"%s\" is required."
+msgstr "« %s » est requis."
 
 #, python-format
-msgid "The values of \"%s\" are not valid"
-msgstr "Les valeurs de « %s » ne sont pas valides"
+msgid "The values of \"%s\" are not valid."
+msgstr "Les valeurs de « %s » ne sont pas valides."
 
 msgid "Pre-validation"
 msgstr "Pré-validation"


### PR DESCRIPTION
Fix missing translation until they are fixed upstream in the next major version.

Fix #17808