### PR TITLE
Force Screen's current_record to the one triggerring the action

### DIFF
--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -1233,7 +1233,6 @@ class Screen(SignalEvent):
         self.reload(ids, written=True)
         if isinstance(action, str):
             self.client_action(action)
-        print('_button_class', self.current_record.id)
         if action_id:
             Action.execute(action_id, {
                     'model': self.model_name,

--- a/tryton/gui/window/view_form/screen/screen.py
+++ b/tryton/gui/window/view_form/screen/screen.py
@@ -746,7 +746,7 @@ class Screen(SignalEvent):
             self.group.written(ids)
         if self.parent:
             self.parent.root_parent.reload()
-        self.display()
+        record_id = self.current_record.id if self.current_record else None
         if self._multiview_form:
             root_parent = self.current_record.root_parent
             assert root_parent.model_name \
@@ -754,6 +754,7 @@ class Screen(SignalEvent):
                     root_parent.model_name, 'is not',
                     self._multiview_form.screen.model_name)
             self._multiview_form.screen.reload([root_parent.id])
+        self.display(res_id=record_id)
 
     def unremove(self):
         records = self.selected_records
@@ -1211,7 +1212,6 @@ class Screen(SignalEvent):
 
     def _button_class(self, button):
         ids = [r.id for r in self.selected_records]
-        current_id = self.current_record.id
         context = self.context
         context['_timestamp'] = {}
         for record in self.selected_records:
@@ -1233,10 +1233,11 @@ class Screen(SignalEvent):
         self.reload(ids, written=True)
         if isinstance(action, str):
             self.client_action(action)
+        print('_button_class', self.current_record.id)
         if action_id:
             Action.execute(action_id, {
                     'model': self.model_name,
-                    'id': current_id,
+                    'id': self.current_record.id,
                     'ids': ids,
                     }, context=self.context, keyword=True)
 


### PR DESCRIPTION
Cette solution garanti que le current_record est setté quand l'action est appelée.

J'ai bien essayé de cherché à synchroniser l'affichage de la form et du tree mais vu que le screen n'est pas partagé c'est un peu le bordel. Je pense que la solution c'est la proposition que nous avons faite dans la vieille issue qui cherche à rendre ça générique (un nouveau type de vue qui afficherait à la fois un arbre et un formulaire mais en partageant le screen). Évidemment ça ne résoud pas tout vu que le clic sur le boutton est toujours quelque chose qu'il faudrait traiter dans votre fork mais au moins la synchro devrait être bonne.