### PR TITLE
Use *-changed events of generic date and time widgets [PREVIEW]

### DIFF
--- a/tryton/common/datetime_.py
+++ b/tryton/common/datetime_.py
@@ -153,10 +153,6 @@ class Date(Gtk.Entry):
         year, month, day = self.__calendar.get_date()
         self.__date = datetime.date(year, month + 1, day)
 
-        self.update_label()
-
-        self.emit('date-changed')
-
     def cal_popup_double_click(self, calendar):
         self.cal_popup_hide()
 

--- a/tryton/common/datetime_.py
+++ b/tryton/common/datetime_.py
@@ -154,6 +154,7 @@ class Date(Gtk.Entry):
         self.__date = datetime.date(year, month + 1, day)
 
     def cal_popup_double_click(self, calendar):
+        self.cal_popup_changed(calendar)
         self.cal_popup_hide()
 
     def cal_popup_key_pressed(self, calendar, event):
@@ -182,6 +183,7 @@ class Date(Gtk.Entry):
     def cal_popup_hide(self):
         popup_hide(self.__cal_popup)
         self.grab_focus()
+        self.update_label()
         self.emit('date-changed')
 
     def cal_popup_is_visible(self):

--- a/tryton/gui/window/view_form/view/form_gtk/calendar_.py
+++ b/tryton/gui/window/view_form/view/form_gtk/calendar_.py
@@ -24,8 +24,7 @@ class Date(Widget):
         self.real_entry.connect('key_press_event', self.sig_key_press)
         self.real_entry.connect('activate', self.sig_activate)
         self.real_entry.connect('changed', lambda _: self.send_modified())
-        self.real_entry.connect('focus-out-event',
-            lambda x, y: self._focus_out())
+        self.entry.connect('date-changed', self.changed)
         self.widget.pack_start(self.entry, expand=False, fill=False, padding=0)
 
     @property
@@ -54,6 +53,13 @@ class Date(Widget):
             field_value = self.cast(self.field.get_client(self.record))
             return field_value != self.get_value()
         return False
+
+    def changed(self, widget):
+        def focus_out():
+            if widget.props.window:
+                self._focus_out()
+        # Must be deferred because it triggers a display of the form
+        GLib.idle_add(focus_out)
 
     def sig_key_press(self, widget, event):
         self.send_modified()
@@ -114,15 +120,6 @@ class Time(Date):
             format_ = '%X'
         self.entry.props.format = format_
 
-    def changed(self, combobox):
-        def focus_out():
-            if combobox.props.window:
-                self._focus_out()
-        # Only when changed from pop list
-        if not combobox.get_child().has_focus():
-            # Must be deferred because it triggers a display of the form
-            GLib.idle_add(focus_out)
-
 
 class DateTime(Date):
     def __init__(self, view, attrs):
@@ -138,7 +135,7 @@ class DateTime(Date):
             child.connect('key_press_event', self.sig_key_press)
             child.connect('activate', self.sig_activate)
             child.connect('changed', lambda _: self.send_modified())
-            child.connect('focus-out-event', lambda x, y: self._focus_out())
+        self.entry.connect('datetime-changed', self.changed)
         self.widget.pack_start(self.entry, expand=False, fill=False, padding=0)
 
     @classmethod


### PR DESCRIPTION
This ensures to detect all changes of the widgets without relying on implementation details.

issue11659
review421571003