### PR TITLE
Fix crash on focus out event

### DIFF
--- a/tryton/gui/window/view_form/view/form_gtk/many2many.py
+++ b/tryton/gui/window/view_form/view/form_gtk/many2many.py
@@ -47,8 +47,8 @@ class Many2Many(Widget):
         self.wid_text = Gtk.Entry()
         self.wid_text.set_placeholder_text(_('Search'))
         self.wid_text.set_property('width_chars', 13)
-        self.focus_out_id = self.wid_text.connect(
-            'focus-out-event', self._focus_out)
+        self.focus_out_id = self.wid_text.connect('focus-out-event',
+            lambda *a: self._focus_out())
         self.focus_out = True
         hbox.pack_start(self.wid_text, expand=True, fill=True, padding=0)
 

--- a/tryton/gui/window/view_form/view/form_gtk/one2many.py
+++ b/tryton/gui/window/view_form/view/form_gtk/one2many.py
@@ -85,7 +85,7 @@ class One2Many(Widget):
             self.wid_text.set_placeholder_text(_('Search'))
             self.wid_text.set_property('width_chars', 13)
             self.pid_focus = self.wid_text.connect('focus-out-event',
-                self._focus_out)
+                lambda *a: self._focus_out())
             hbox.pack_start(self.wid_text, expand=True, fill=True, padding=0)
 
             if int(self.attrs.get('completion', 1)):


### PR DESCRIPTION
Fix #24366

Do not pass event arguments to _focus_out methods which does not take any.