### PR TITLE
Trigger group_list_changed to all screens linked to the group [PREVIEW]

### DIFF
--- a/tryton/gui/window/view_form/model/group.py
+++ b/tryton/gui/window/view_form/model/group.py
@@ -514,14 +514,17 @@ class Group(list):
         return record
 
     def _group_list_changed(self, action, *args):
-        group = self
-        while group.parent:
-            if group.model_name != group.parent.model_name:
-                break
-            else:
-                group = group.parent.group
-        for screen in group.screens:
-            screen.group_list_changed(group, action, *args)
+        def groups(group):
+            yield group
+            while group.parent:
+                if group.model_name != group.parent.model_name:
+                    break
+                else:
+                    group = group.parent.group
+                    yield group
+        for group in groups(self):
+            for screen in group.screens:
+                screen.group_list_changed(group, action, *args)
 
     def record_modified(self):
         if not self.parent:


### PR DESCRIPTION
In a tree structure a group and its parent can be linked at any level to a screen which may have tree views for which the model must be updated.

issue11809
review428041003