### PR TITLE
prevent the reset of a WizardForm view when the user comes back to it

### DIFF
--- a/tryton/gui/window/wizard.py
+++ b/tryton/gui/window/wizard.py
@@ -298,7 +298,7 @@ class WizardForm(Wizard, TabContent):
 
     def set_cursor(self):
         if self.screen:
-            self.screen.set_cursor()
+            self.screen.set_cursor(reset_view=False)
 
 
 class WizardDialog(Wizard, NoModal):


### PR DESCRIPTION
Fix #PJAZZ-898